### PR TITLE
updated models to support background images

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -8,5 +8,6 @@ exclude =
     docs/tools/
     reproschema/_version.py
     reproschema/models/model.py
+    *venv*
 max-line-length=79
 extend-ignore = B001, B006, B016, E501, E722, F821

--- a/reproschema/cli.py
+++ b/reproschema/cli.py
@@ -302,3 +302,9 @@ def reproschema2fhir(reproschema_questionnaire, output):
 
         with open(output_path / f"{file_name}/{file_name}.json", "w+") as f:
             f.write(json.dumps(fhir_questionnaire))
+
+
+if __name__ == "__main__":
+    import sys
+
+    main(prog_name="reproschema")

--- a/reproschema/cli.py
+++ b/reproschema/cli.py
@@ -305,6 +305,4 @@ def reproschema2fhir(reproschema_questionnaire, output):
 
 
 if __name__ == "__main__":
-    import sys
-
     main(prog_name="reproschema")

--- a/reproschema/models/model.py
+++ b/reproschema/models/model.py
@@ -246,6 +246,23 @@ class AdditionalProperty(Thing):
         description="Background image for drawing activities.",
     )
 
+    @model_validator(mode="after")
+    def validate_only_background_image_extra(self):
+        """Validate that only backgroundImage is allowed as an extra field."""
+        # Get any extra fields that weren't explicitly defined
+        extra_fields = getattr(self, "__pydantic_extra__", {})
+
+        if extra_fields:
+            # Since backgroundImage is now an explicit field, any extra fields are not allowed
+            extra_field_names = list(extra_fields.keys())
+            raise ValueError(
+                f"Extra fields are not permitted in AdditionalProperty. "
+                f"Only 'backgroundImage' is allowed as an additional field, "
+                f"but found: {extra_field_names}"
+            )
+
+        return self
+
     id: Optional[str] = Field(
         None,
         description="A unique identifier for an entity. Must be either a CURIE shorthand for a URI or a complete URI.",

--- a/reproschema/models/model.py
+++ b/reproschema/models/model.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-import re
-import sys
 from datetime import date, datetime
 from decimal import Decimal
 from enum import Enum

--- a/reproschema/models/model.py
+++ b/reproschema/models/model.py
@@ -10,7 +10,13 @@ from typing import Any, Dict, List, Literal, Optional, Union
 from pydantic.version import VERSION as PYDANTIC_VERSION
 
 if int(PYDANTIC_VERSION[0]) >= 2:
-    from pydantic import BaseModel, ConfigDict, Field, field_validator
+    from pydantic import (
+        BaseModel,
+        ConfigDict,
+        Field,
+        field_validator,
+        model_validator,
+    )
 else:
     from pydantic import BaseModel, Field, validator
 metamodel_version = "None"
@@ -178,6 +184,9 @@ class AdditionalProperty(Thing):
     An object to describe the various properties added to assessments and Items.
     """
 
+    # Override parent's extra="forbid" to allow extra fields
+    model_config = ConfigDict(extra="allow")
+
     allow: Optional[List[AllowedType]] = Field(
         default_factory=list,
         title="allow",
@@ -229,6 +238,14 @@ class AdditionalProperty(Thing):
         title="UI",
         description="An element to control UI specifications. Originally @nest in jsonld, but using a class in the model.",
     )
+
+    # Add backgroundImage as an explicit field to allow it
+    backgroundImage: Optional[str] = Field(
+        None,
+        title="backgroundImage",
+        description="Background image for drawing activities.",
+    )
+
     id: Optional[str] = Field(
         None,
         description="A unique identifier for an entity. Must be either a CURIE shorthand for a URI or a complete URI.",

--- a/reproschema/models/tests/test_schema.py
+++ b/reproschema/models/tests/test_schema.py
@@ -238,6 +238,33 @@ def test_background_image_always_allowed():
     )
 
 
+def test_extra_fields_rejected():
+    """Test that extra fields other than backgroundImage are rejected."""
+    activity_dict = {
+        "category": "Activity",
+        "id": "activity_with_invalid_extra.jsonld",
+        "prefLabel": {"en": "Activity with Invalid Extra Field"},
+        "description": {"en": "An activity with an invalid extra field"},
+        "schemaVersion": "1.0.0-rc4",
+        "version": "0.0.1",
+        "ui": {
+            "inputType": "radio",
+            "addProperties": [
+                {
+                    "isAbout": "item1",
+                    "variableName": "test_item",
+                    "backgroundImage": "./images/test.png",  # This is allowed
+                    "customTool": "special_pen",  # This should be rejected
+                }
+            ],
+        },
+    }
+
+    # This should fail because customTool is not allowed
+    with pytest.raises(ValueError, match="Extra fields are not permitted"):
+        Activity(**activity_dict)
+
+
 def test_activity_without_extra_fields_works():
     """Test that activities without extra fields work normally regardless of input type."""
     activity_dict = {


### PR DESCRIPTION
This was mainly added so that a background image could be applied to a protocol/input for the recently added cavas attribute at https://github.com/ReproNim/reproschema-ui/pull/363

Potentially allows for background use in other activities b/c it was easier to minimally implement and/or one could add a background image/logo or something for their own protocol.

Helps resolve failing CI at https://github.com/ReproNim/demo-protocol/pull/33

